### PR TITLE
Git: update Husky pre-commit for POSIX sh Compatibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,11 +5,11 @@
 cd "$(dirname -- "$0")/.." || exit 1
 
 # Ensure node is available (same as asciinema-rec.sh)
-if [[ ! -x "$(command -v node)" ]]; then
-  if [[ ! -x "$(command -v nvm)" && -f ~/.nvm/nvm.sh ]]; then
+if [ ! -x "$(command -v node)" ]; then
+  if [ ! -x "$(command -v nvm)" ] && [ -f ~/.nvm/nvm.sh ]; then
     . ~/.nvm/nvm.sh
   fi
-  if [[ ! -x "$(command -v nvm)" ]]; then
+  if [ ! -x "$(command -v nvm)" ]; then
     nvm install || true
     nvm use || exit 1
   fi
@@ -17,7 +17,7 @@ fi
 node --version &> /dev/null || exit 1
 
 # Ensure node modules are installed
-if [[ ! -d "node_modules" ]]; then
+if [ ! -d "node_modules" ]; then
   npm ci
 fi
 


### PR DESCRIPTION
Removes the use of double brackets, which is not compatible with all shell implementations.