### PR TITLE
Fix: don't infer parents for DATs that already have parent/clone info

### DIFF
--- a/src/modules/datParentInferrer.ts
+++ b/src/modules/datParentInferrer.ts
@@ -21,6 +21,11 @@ export default class DATParentInferrer extends Module {
   async infer(dat: DAT): Promise<DAT> {
     this.progressBar.logInfo(`inferring parents for ${dat.getGames().length.toLocaleString()} game${dat.getGames().length !== 1 ? 's' : ''}`);
 
+    if (dat.hasParentCloneInfo()) {
+      this.progressBar.logDebug(`${dat.getNameShort()}: DAT has parent/clone info, skipping`);
+      return dat;
+    }
+
     if (!dat.getGames().length) {
       this.progressBar.logDebug(`${dat.getNameShort()}: no games to process`);
       return dat;

--- a/test/modules/datParentInferrer.test.ts
+++ b/test/modules/datParentInferrer.test.ts
@@ -12,6 +12,31 @@ function buildDat(gameNames: string[]): DAT {
   );
 }
 
+it('should not do anything if the DAT has parent/clone info', async () => {
+  // Given
+  const dat = new LogiqxDAT(new Header(), [
+    new Game({ name: 'game one' }),
+    new Game({ name: 'game two', cloneOf: 'game one' }),
+  ]);
+
+  // When
+  const inferredDat = await new DATParentInferrer(new ProgressBarFake()).infer(dat);
+
+  // Then
+  expect(inferredDat === dat).toEqual(true);
+});
+
+it('should not do anything if the DAT has no games', async () => {
+  // Given
+  const dat = new LogiqxDAT(new Header(), []);
+
+  // When
+  const inferredDat = await new DATParentInferrer(new ProgressBarFake()).infer(dat);
+
+  // Then
+  expect(inferredDat === dat).toEqual(true);
+});
+
 test.each([
   [[
     'Pikmin (Europe) (En,Fr,De,Es,It)',


### PR DESCRIPTION
Fixes: https://github.com/emmercm/igir/issues/720