### PR TITLE
Feature: output token {miyoocfw} for Bittboy/Powkiddy custom firmware MiyooCFW

### DIFF
--- a/docs/output/tokens.md
+++ b/docs/output/tokens.md
@@ -73,6 +73,7 @@ To help sort ROMs into unique file structures for popular frontends & hardware, 
 
 - `{batocera}` the [Batocera](../usage/desktop/batocera.md) emulator's directory for the ROM
 - `{funkeyos}` the [FunKey OS](../usage/handheld/funkeyos.md) emulator's directory for the ROM
+- `{miyoocfw}` the [MiyooCFW](../usage/handheld/miyoocfw.md) emulator's directory for the ROM
 - `{jelos}` the [JELOS](../usage/handheld/jelos.md) emulator's directory for the ROM
 - `{mister}` the [MiSTer FPGA](../usage/hardware/mister.md) core's directory for the ROM
 - `{onion}` the [OnionOS / GarlicOS](../usage/handheld/onionos.md) emulator's directory for the ROM

--- a/docs/usage/handheld/miyoocfw.md
+++ b/docs/usage/handheld/miyoocfw.md
@@ -5,7 +5,10 @@
 ## BIOS Files
 
 MiyooCFW doesn't seem to have a centralized folder for putting BIOS files so it's a chore to prepare the card for running the provided emulators. Here's a try to help with finding the right ones and putting them in the right place.
-Please keep in mind that this information is based on the table in the official [MiyooCFW Emulator Info](https://github.com/TriForceX/MiyooCFW/wiki/Emulator-Info) and might be out of date. Please refer to the official list for reference.
+
+!!! info
+
+    Please keep in mind that this information is based on the table in the official [MiyooCFW Emulator Info](https://github.com/TriForceX/MiyooCFW/wiki/Emulator-Info) and might be out of date. Please refer to the official list for reference.
 
 | System   | Emulator | Folder | Filenames | MD5SUMs | Comments |
 |----------|----------|--------|-----------|---------|----------|

--- a/docs/usage/handheld/miyoocfw.md
+++ b/docs/usage/handheld/miyoocfw.md
@@ -1,0 +1,63 @@
+# MiyooCFW
+
+[MiyooCFW](https://github.com/TriForceX/MiyooCFW/wiki) ([Code](https://github.com/TriForceX/MiyooCFW)) is a custom firmware  for BittBoy, PocketGo, PowKiddy V90-Q90-Q20 and third party handheld consoles. It is based on the buildroot build environment and loosely based on OpenDingux. While it is intended for the named less powerful handhelds, it packs a good and wide selection of emulators. Some tinkering with the BIOS files is required though, but no worries, most of that is covered below or in their [Wiki](https://github.com/TriForceX/MiyooCFW/wiki/Emulator-Info)
+
+## BIOS Files
+
+MiyooCFW doesn't seem to have a centralized folder for putting BIOS files so it's a chore to prepare the card for running the provided emulators. Here's a try to help with finding the right ones and putting them in the right place.
+
+| System   | Emulator | Folder | Filenames | MD5SUMs | Comments |
+|----------|----------|--------|-----------|---------|----------|
+|  GB/GBC  | Gambatte | /.gambatte/bios/BIOS | `gb_bios.bin` &#10; `gbc_bios.bin` |  `32fbbd84168d3482956eb3c5051637f5` &#10; `dbfce9db9deaa2567f6a84fde55f9680`      |  Only required for authentic boot screen         |
+| GBA      | GPSP     | /emus/gpsp_gameblabla/ | `gba_bios.bin` | `a860e8c0b6d573d191e4ec7db1b1e4f6` | |
+| GBA      | GPSP Rumble    | /emus/gpsp/ | `gba_bios.bin` | `a860e8c0b6d573d191e4ec7db1b1e4f6` | |
+| NES      | FCEUX    | /.fceux/ | `disksys.rom` |  `ca30b50f880eb660a320674ed365ef7a` | For Famicom Disk System |
+| Sega Master System / Game Gear | SMS Plus GX | /emus/smsplusgx/bios/ | `BIOS.col` | `840481177270d5642a14ca71ee72844c` | System.dat calls this `bios.sms` |
+| Sega Megadrive / Genesis | Picodrive | /.picodrive/ | `bios_cd_e.bin` &#10; `bios_cd_j.bin` &#10; `bios_cd_u.bin` | `e66fa1dc5820d254611fdcdba0662372` &#10; `278a9397d192149e84e820ac621a8edd` &#10; `2efd74e3232ff260e371b99f84024f7f` | for Mega-CD only. System.dat uses different casing. |
+| PC Engine / Turbogfx-16 | Temper | /.temper/syscards/ | `syscard3.pce` | `38179df8f4ac870017db21ebcbf53114` | for CD based games |
+| SNK NeoGeo | GNGeo | /roms/NEOGEO/ | `NEOGEO.zip` | unknown | version from FBA 0.2.97.39 works |
+| Sony PlayStation 1 | PCSX ReARMed | /emus/pcsx_rearmed/bios/ | `SCPH1001.BIN` | `924e392ed05558ffdb115408c263dccf` | Optional but required for LLE, activate in options |
+| GCE Vectrex | Vecxemu | /.vecxemu/ | `rom.dat` | `ab082fa8c8e632dd68589a8c7741388f` | not part of 'System.dat', available as part of vecxemu [here](https://github.com/gameblabla/vecxemu/raw/master/rom.dat) |
+
+## ROMs
+
+MiyooCFW supports many many systems and ROM formats. Check the table on the [MiyooCFW Wiki](https://github.com/TriForceX/MiyooCFW/wiki/Emulator-Info) for more precise instructions about the indivudual systems. Most supported systems and their ROMS can be automatically sorted by `igir` using the `{miyoocfw}` output token. See the [replaceable tokens page](../../output/tokens.md) for more information.
+
+=== ":simple-windowsxp: Windows"
+
+    Replace the `E:\` drive letter with wherever your SD card is:
+
+    ```batch
+    igir copy extract test clean ^
+      --dat "No-Intro*.zip" ^
+      --input ROMs\ ^
+      --output "E:\roms\{miyoocfw}" ^
+      --dir-letter ^
+      --no-bios
+    ```
+
+=== ":simple-apple: macOS"
+
+    Replace the `/Volumes/MiyooCFW` drive name with whatever your SD card is named:
+
+    ```shell
+    igir copy extract test clean \
+      --dat "No-Intro*.zip" \
+      --input ROMs/ \
+      --output "/Volumes/MiyooCFW/roms/{miyoocfw}" \
+      --dir-letter \
+      --no-bios
+    ```
+
+=== ":simple-linux: Linux"
+
+    Replace the `/media/MiyooCFW` path with wherever your SD card is mounted:
+
+    ```shell
+    igir copy extract test clean \
+      --dat "No-Intro*.zip" \
+      --input ROMs/ \
+      --output "/media/MiyooCFW/roms/{miyoocfw}" \
+      --dir-letter \
+      --no-bios
+    ```

--- a/docs/usage/handheld/miyoocfw.md
+++ b/docs/usage/handheld/miyoocfw.md
@@ -5,6 +5,7 @@
 ## BIOS Files
 
 MiyooCFW doesn't seem to have a centralized folder for putting BIOS files so it's a chore to prepare the card for running the provided emulators. Here's a try to help with finding the right ones and putting them in the right place.
+Please keep in mind that this information is based on the table in the official [MiyooCFW Emulator Info](https://github.com/TriForceX/MiyooCFW/wiki/Emulator-Info) and might be out of date. Please refer to the official list for reference.
 
 | System   | Emulator | Folder | Filenames | MD5SUMs | Comments |
 |----------|----------|--------|-----------|---------|----------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
             - usage/handheld/jelos.md
             - usage/desktop/lakka.md
             - usage/desktop/launchbox.md
+            - usage/handheld/miyoocfw.md
             - usage/handheld/onionos.md
             - usage/desktop/openemu.md
             - usage/desktop/recalbox.md

--- a/src/modules/argumentsParser.ts
+++ b/src/modules/argumentsParser.ts
@@ -683,6 +683,7 @@ Advanced usage:
     {batocera}  The ROM's emulator-specific /roms/* directory for Batocera (e.g. "gb")
     {jelos}     The ROM's emulator-specific /roms/* directory for JELOS (e.g. "gb")
     {funkeyos}  The ROM's emulator-specific /* directory for FunKey OS (e.g. "Game Boy")
+    {miyoocfw}  The ROM's emulator-specific /roms/* directory for MiyooCFW (e.g. "GB")
 
 Example use cases:
 

--- a/src/types/gameConsole.ts
+++ b/src/types/gameConsole.ts
@@ -25,6 +25,10 @@ interface OutputTokens {
   // FunKey S ROMs go into the subfolder of / for the console:
   // @see https://github.com/FunKey-Project/FunKey-OS/tree/master/FunKey/board/funkey/rootfs-overlay/usr/games/collections
   funkeyos?: string,
+
+  // MiyooCFW Roms go into the /roms subfolder of the SD card
+  // @see https://github.com/TriForceX/MiyooCFW/wiki/Emulator-Info
+  miyoocfw?: string,
 }
 
 /**
@@ -82,6 +86,7 @@ export default class GameConsole {
       onion: 'ATARI',
       batocera: 'atari2600',
       jelos: 'atari2600',
+      miyoocfw: '2600',
     }),
     new GameConsole(/5200/, ['.a52'], {
       mister: 'Atari5200',
@@ -107,6 +112,7 @@ export default class GameConsole {
       batocera: 'lynx',
       jelos: 'atarilynx',
       funkeyos: 'Atari lynx',
+      miyoocfw: 'LYNX',
     }),
     new GameConsole(/Atari.*ST/i, ['.msa', '.st', '.stx'], {
       mister: 'AtariST',
@@ -133,6 +139,7 @@ export default class GameConsole {
       batocera: 'wswan',
       jelos: 'wonderswan',
       funkeyos: 'WonderSwan',
+      miyoocfw: 'WSWAN',
     }),
     new GameConsole(/WonderSwan Color/i, ['.wsc'], {
       pocket: 'wonderswan',
@@ -141,6 +148,7 @@ export default class GameConsole {
       batocera: 'wswanc',
       jelos: 'wonderswancolor',
       funkeyos: 'WonderSwan',
+      miyoocfw: 'WSWAN', // TODO: check if this works
     }),
     // Bit Corporation
     new GameConsole(/Gamate/i, [/* '.bin' */], {
@@ -230,6 +238,7 @@ export default class GameConsole {
       onion: 'VECTREX',
       batocera: 'vectrex',
       jelos: 'vectrex',
+      miyoocfw: 'VECTREX',
     }),
     // Interton
     new GameConsole(/VC ?4000/i, [/* '.bin' */], {
@@ -294,6 +303,7 @@ export default class GameConsole {
       batocera: 'pcengine',
       jelos: 'tg16',
       funkeyos: 'PCE-TurboGrafx',
+      miyoocfw: 'PCE',
     }),
     new GameConsole(/(PC Engine|TurboGrafx) CD/i, [/* '.bin', '.cue' */], {
       pocket: 'pcecd',
@@ -301,6 +311,7 @@ export default class GameConsole {
       onion: 'PCECD',
       batocera: 'pcenginecd',
       jelos: 'tg16cd',
+      miyoocfw: 'PCE',
     }),
     new GameConsole(/SuperGrafx/i, ['.sgx'], {
       pocket: 'pce',
@@ -328,6 +339,7 @@ export default class GameConsole {
       batocera: 'fds',
       jelos: 'fds',
       funkeyos: 'NES',
+      miyoocfw: 'NES',
     }),
     new GameConsole(/Game (and|&) Watch/i, ['.mgw'], {
       mister: 'GameNWatch',
@@ -346,6 +358,7 @@ export default class GameConsole {
       batocera: 'gb',
       jelos: 'gb',
       funkeyos: 'Game Boy',
+      miyoocfw: 'GB',
     }), // pocket:sgb for spiritualized1997
     new GameConsole(/GBA|Game ?Boy Advance/i, ['.gba', '.srl'], {
       pocket: 'gba',
@@ -354,6 +367,7 @@ export default class GameConsole {
       batocera: 'gba',
       jelos: 'gba',
       funkeyos: 'Game Boy Advance',
+      miyoocfw: 'GBA',
     }),
     new GameConsole(/GBC|Game ?Boy Color/i, ['.gbc'], {
       pocket: 'gbc',
@@ -362,6 +376,7 @@ export default class GameConsole {
       batocera: 'gbc',
       jelos: 'gbc',
       funkeyos: 'Game Boy Color',
+      miyoocfw: 'GB',
     }),
     new GameConsole(/Nintendo 64|N64/i, ['.n64', '.v64', '.z64'], {
       mister: 'N64',
@@ -386,6 +401,7 @@ export default class GameConsole {
       batocera: 'nes',
       jelos: 'nes',
       funkeyos: 'NES',
+      miyoocfw: 'NES',
     }),
     new GameConsole(/Pokemon Mini/i, ['.min'], {
       pocket: 'poke_mini',
@@ -394,6 +410,7 @@ export default class GameConsole {
       batocera: 'pokemini',
       jelos: 'pokemini',
       funkeyos: 'Pokemini',
+      miyoocfw: 'POKEMINI',
     }),
     new GameConsole(/Satellaview/i, ['.bs'], {
       pocket: 'snes',
@@ -414,6 +431,7 @@ export default class GameConsole {
       batocera: 'snes',
       jelos: 'snes',
       funkeyos: 'SNES',
+      miyoocfw: 'SNES',
     }),
     new GameConsole(/Virtual Boy/i, ['.vb', '.vboy'], {
       onion: 'VB',
@@ -467,6 +485,7 @@ export default class GameConsole {
       batocera: 'gamegear',
       jelos: 'gamegear',
       funkeyos: 'Game Gear',
+      miyoocfw: 'SMS',
     }),
     new GameConsole(/Master System/i, ['.sms'], {
       pocket: 'sms',
@@ -475,12 +494,14 @@ export default class GameConsole {
       batocera: 'mastersystem',
       jelos: 'mastersystem',
       funkeyos: 'Sega Master System',
+      miyoocfw: 'SMS',
     }),
     new GameConsole(/(Mega|Sega) CD/i, [/* '.bin', '.cue' */], {
       mister: 'MegaCD',
       onion: 'SEGACD',
       batocera: 'segacd',
       jelos: 'segacd',
+      miyoocfw: 'SMD',
     }),
     new GameConsole(/Mega Drive|Genesis/i, ['.gen', '.md', '.mdx', '.sgd', '.smd'], {
       pocket: 'genesis',
@@ -489,6 +510,7 @@ export default class GameConsole {
       batocera: 'megadrive',
       jelos: 'genesis',
       funkeyos: 'Sega Genesis',
+      miyoocfw: 'SMD',
     }),
     new GameConsole(/Saturn/i, [/* '.bin', '.cue' */], {
       batocera: 'saturn',
@@ -538,6 +560,7 @@ export default class GameConsole {
       onion: 'NEOGEO',
       batocera: 'neogeo',
       jelos: 'neogeo',
+      miyoocfw: 'NEOGEO',
     }),
     new GameConsole(/Neo ?Geo CD/i, [/* '.bin', '.cue' */], {
       onion: 'NEOCD',
@@ -563,6 +586,7 @@ export default class GameConsole {
       batocera: 'psx',
       jelos: 'psx',
       funkeyos: 'PS1',
+      miyoocfw: 'PS1',
     }),
     new GameConsole(/PlayStation 2|ps2/i, [/* '.bin', '.cue' */], {
       batocera: 'ps2',
@@ -661,5 +685,9 @@ export default class GameConsole {
 
   getFunkeyOS(): string | undefined {
     return this.outputTokens.funkeyos;
+  }
+
+  getMiyooCFW(): string | undefined {
+    return this.outputTokens.miyoocfw;
   }
 }

--- a/src/types/outputFactory.ts
+++ b/src/types/outputFactory.ts
@@ -293,6 +293,11 @@ export default class OutputFactory {
     if (funkeyos) {
       output = output.replace('{funkeyos}', funkeyos);
     }
+
+    const miyoocfw = gameConsole.getMiyooCFW();
+    if (miyoocfw) {
+      output = output.replace('{miyoocfw}', miyoocfw);
+    }
     return output;
   }
 

--- a/test/outputFactory.test.ts
+++ b/test/outputFactory.test.ts
@@ -581,7 +581,7 @@ describe('token replacement', () => {
   test.each([
     'game.bin',
     'game.rom',
-    // satellaview is not supported by https://github.com/DS-Homebrew/TWiLightMenu/tree/master/7zfile/roms/snes
+    // satellaview is not supported by https://github.com/TriForceX/MiyooCFW/wiki/Emulator-Info
     'game.bs',
   ])(
     'should throw on {miyoocfw} for unknown extension: %s',

--- a/test/outputFactory.test.ts
+++ b/test/outputFactory.test.ts
@@ -537,6 +537,69 @@ describe('token replacement', () => {
       )).rejects.toThrow(/failed to replace/);
     },
   );
+
+  test.each([
+    ['game.a26', path.join('roms', '2600', 'game.a26')],
+    ['game.lnx', path.join('roms', 'LYNX', 'game.lnx')],
+    ['game.ws', path.join('roms', 'WSWAN', 'game.ws')],
+    ['game.wsc', path.join('roms', 'WSWAN', 'game.wsc')], // TODO: check if this works
+    ['game.vec', path.join('roms', 'VECTREX', 'game.vec')],
+    ['game.pce', path.join('roms', 'PCE', 'game.pce')],
+    ['game.gb', path.join('roms', 'GB', 'game.gb')],
+    ['game.sgb', path.join('roms', 'GB', 'game.sgb')],
+    ['game.gbc', path.join('roms', 'GB', 'game.gbc')],
+    ['game.gba', path.join('roms', 'GBA', 'game.gba')],
+    ['game.srl', path.join('roms', 'GBA', 'game.srl')],
+    ['game.nes', path.join('roms', 'NES', 'game.nes')],
+    ['game.fds', path.join('roms', 'NES', 'game.fds')],
+    ['game.sfc', path.join('roms', 'SNES', 'game.sfc')],
+    ['game.smc', path.join('roms', 'SNES', 'game.smc')],
+    ['game.min', path.join('roms', 'POKEMINI', 'game.min')],
+    ['game.gg', path.join('roms', 'SMS', 'game.gg')],
+    ['game.sms', path.join('roms', 'SMS', 'game.sms')],
+    ['game.gen', path.join('roms', 'SMD', 'game.gen')],
+    ['game.md', path.join('roms', 'SMD', 'game.md')],
+    ['game.smd', path.join('roms', 'SMD', 'game.smd')],
+  ])(
+    'should replace {miyoocfw} for known extension: %s',
+    async (outputRomFilename, expectedPath) => {
+      const options = new Options({ commands: ['copy'], output: 'roms/{miyoocfw}' });
+      const rom = new ROM({ name: outputRomFilename, size: 0, crc: '' });
+
+      const outputPath = OutputFactory.getPath(
+        options,
+        dummyDat,
+        dummyGame,
+        dummyRelease,
+        rom,
+        await rom.toFile(),
+      );
+      expect(outputPath.format()).toEqual(expectedPath);
+    },
+  );
+
+  test.each([
+    'game.bin',
+    'game.rom',
+    // satellaview is not supported by https://github.com/DS-Homebrew/TWiLightMenu/tree/master/7zfile/roms/snes
+    'game.bs',
+  ])(
+    'should throw on {miyoocfw} for unknown extension: %s',
+    async (outputRomFilename) => {
+      const options = new Options({ commands: ['copy'], output: 'roms/{miyoocfw}' });
+
+      const rom = new ROM({ name: outputRomFilename, size: 0, crc: '' });
+
+      await expect(async () => OutputFactory.getPath(
+        options,
+        dummyDat,
+        dummyGame,
+        dummyRelease,
+        rom,
+        await rom.toFile(),
+      )).rejects.toThrow(/failed to replace/);
+    },
+  );
 });
 
 describe('should respect "--dir-mirror"', () => {


### PR DESCRIPTION
I want to add sorting support for [MiyooCFW](https://github.com/TriForceX/MiyooCFW/wiki/)

it can be used on the compact handheld firmware for some Bittboy, powkiddy (V/Q 20/90) and PocketGo devices. Work in progress.

I messed up the branch in my previous pull request. I am very sorry, if this wasted any resources, please let me make it up with a donation to the project. 

This is a draft based on the main before merge of PR#804. If that one gets merged I will rebase, if not I will submit this as is.