### PR TITLE
Fix: don't leave open file handles when hashing zip entries

### DIFF
--- a/src/polyfill/streamPoly.ts
+++ b/src/polyfill/streamPoly.ts
@@ -1,0 +1,23 @@
+import { Readable, Writable } from 'node:stream';
+
+export default {
+  async autodrain(stream: Readable): Promise<void> {
+    // https://github.com/sindresorhus/noop-stream/blob/1ae9ff0dce4a895064ed31f90787f53d5faf1330/index.js#L37-L42
+    const noOpStream = new Writable({
+      write(
+        chunk: never,
+        encoding: BufferEncoding,
+        callback: (error?: (Error | null)) => void,
+      ): void {
+        setImmediate(callback);
+      },
+    });
+
+    // https://github.com/ZJONSSON/node-unzipper/blob/ab64d6a38b5f091384334dd7aff283f0a5073878/lib/parse.js#L118-L124
+    const draining = stream.pipe(noOpStream);
+    return new Promise((resolve, reject) => {
+      draining.on('finish', resolve);
+      draining.on('error', reject);
+    });
+  },
+};

--- a/src/types/files/file.ts
+++ b/src/types/files/file.ts
@@ -200,7 +200,11 @@ export default class File implements FileProps {
         highWaterMark: Constants.FILE_READING_CHUNK_SIZE,
       });
 
-      return FileChecksums.hashStream(stream, checksumBitmask);
+      try {
+        return await FileChecksums.hashStream(stream, checksumBitmask);
+      } finally {
+        stream.destroy();
+      }
     });
   }
 

--- a/src/types/files/fileChecksums.ts
+++ b/src/types/files/fileChecksums.ts
@@ -34,6 +34,7 @@ export default class FileChecksums {
   ): Promise<ChecksumProps> {
     // Not calculating any checksums, do nothing
     if (!checksumBitmask) {
+      // WARN(cemmer): this may leave the stream un-drained and therefore some file handles open!
       return {};
     }
 


### PR DESCRIPTION
Fixes: #885