### PR TITLE
Fix: Update clean dry run to use info logging instead of debug

### DIFF
--- a/src/modules/directoryCleaner.ts
+++ b/src/modules/directoryCleaner.ts
@@ -80,7 +80,7 @@ export default class DirectoryCleaner extends Module {
 
   private async trashOrDelete(filePaths: string[]): Promise<void> {
     if (this.options.getCleanDryRun()) {
-      this.progressBar.logDebug(`paths skipped from cleaning (dry run):\n${filePaths.map((filePath) => `  ${filePath}`).join('\n')}`);
+      this.progressBar.logInfo(`paths skipped from cleaning (dry run):\n${filePaths.map((filePath) => `  ${filePath}`).join('\n')}`);
       return;
     }
 


### PR DESCRIPTION
Hello again!

Based on my comment on the closed issue [here](https://github.com/emmercm/igir/issues/938#issuecomment-1960482147), I think that clean dry run should match the regular clean in terms of logging (on line 90). All of the other logs and their levels are great, just this clean dry run didn't match up.

Thank you!