### PR TITLE
Fix: use node.exe for the caxa command on Windows

### DIFF
--- a/package.ts
+++ b/package.ts
@@ -115,7 +115,7 @@ const fileFilter = (filters: FileFilter[]): string[] => {
     output,
     exclude: excludeGlobs,
     command: [
-      '{{caxa}}/node_modules/.bin/node',
+      `{{caxa}}/node_modules/.bin/node${process.platform === 'win32' ? '.exe' : ''}`,
       '{{caxa}}/dist/index.js',
     ],
   });


### PR DESCRIPTION
RE: https://github.com/emmercm/igir/issues/1084