### PR TITLE
Fix: Revert "Chore: pin dependency python to 3.4.10"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -68,6 +68,13 @@
       schedule: 'at any time'
     },
 
+    // Don't update some packages in GitHub Actions workflows
+    {
+      matchFileNames: ['.github/workflows/**'],
+      matchPackageNames: ['python'],
+      enabled: false,
+    },
+
     // Group any/all package files in the docs/ directory
     {
       matchFileNames: ['docs/**'],

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.4.10
+          python-version: 3.x
       - uses: actions/cache@v4
         with:
           key: ${{ env.ref }}
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.4.10
+          python-version: 3.x
       - uses: actions/cache@v4
         with:
           key: ${{ env.ref }}


### PR DESCRIPTION
Reverts emmercm/igir#1485