### PR TITLE
Fix: don't allow patch options to be used with link command

### DIFF
--- a/src/modules/argumentsParser.ts
+++ b/src/modules/argumentsParser.ts
@@ -384,6 +384,18 @@ export default class ArgumentsParser {
         type: 'array',
         requiresArg: true,
       })
+      .check((checkArgv) => {
+        const illegalPatchCommands = ['link'].filter((command) => checkArgv._.includes(command));
+        if (illegalPatchCommands.length > 0) {
+          const patchOptions = ['patch', 'patch-exclude'].filter((option) => checkArgv[option]);
+          if (patchOptions.length > 0) {
+            throw new IgirException(
+              `Argument${patchOptions.length === 1 ? '' : 's'} ${patchOptions.map((opt) => `"${opt}"`).join(', ')} cannot be used with the command${illegalPatchCommands.length === 1 ? '' : 's'} ${illegalPatchCommands.map((cmd) => `"${cmd}"`).join(', ')}`,
+            );
+          }
+        }
+        return true;
+      })
 
       .option('output', {
         group: groupRomOutputPath,

--- a/test/modules/argumentsParser.test.ts
+++ b/test/modules/argumentsParser.test.ts
@@ -652,7 +652,7 @@ describe('options', () => {
     );
     expect(() =>
       argumentsParser.parse([...dummyCommandAndRequiredArgs, 'dir2dat', '--dat', os.devNull]),
-    ).toThrow();
+    ).toThrow(/cannot be used/i);
     await expect(
       argumentsParser.parse(dummyCommandAndRequiredArgs).scanDatFilesWithoutExclusions(),
     ).rejects.toThrow(/no files found/i);
@@ -1121,6 +1121,17 @@ describe('options', () => {
   });
 
   it('should parse "patch"', async () => {
+    expect(() =>
+      argumentsParser.parse([
+        'link',
+        '--input',
+        os.devNull,
+        '--patch',
+        os.devNull,
+        '--output',
+        os.devNull,
+      ]),
+    ).toThrow(/cannot be used/i);
     await expect(
       argumentsParser
         .parse([


### PR DESCRIPTION
RE: https://github.com/emmercm/igir/issues/1807