### PR TITLE
Fix: don't use 'node-disk-info' on Windows

### DIFF
--- a/src/polyfill/fsPoly.ts
+++ b/src/polyfill/fsPoly.ts
@@ -356,11 +356,11 @@ export default class FsPoly {
     if (
       // Standard UNC: \\Server\Share\Path
       // Extended UNC: \\?\UNC\Server\Share\Path
-      normalizedPath.startsWith('\\\\') ||
+      filePath.startsWith(`\\\\`) ||
       // smb://[user[:password]@]server/share[/path]
-      normalizedPath.toLowerCase().startsWith('smb://') ||
+      filePath.toLowerCase().startsWith('smb://') ||
       // /mnt/smb/share/folder/
-      normalizedPath.toLowerCase().startsWith('/mnt/smb/')
+      filePath.toLowerCase().startsWith('/mnt/smb/')
     ) {
       return true;
     }

--- a/test/polyfill/fsPoly.test.ts
+++ b/test/polyfill/fsPoly.test.ts
@@ -351,9 +351,12 @@ describe('isSamba', () => {
     },
   );
 
-  test.each(['//foo/bar', '\\\\foo\\bar'])('should return true: %s', (filePath) => {
-    expect(FsPoly.isSamba(filePath)).toEqual(true);
-  });
+  test.each(['\\\\foo\\bar', 'smb://foo/bar', '/mnt/smb/foo/bar'])(
+    'should return true: %s',
+    (filePath) => {
+      expect(FsPoly.isSamba(filePath)).toEqual(true);
+    },
+  );
 });
 
 describe('isSymlink', () => {


### PR DESCRIPTION
RE: https://github.com/emmercm/igir/issues/1883