### PR TITLE
Docs: add examples for other CRC32s in patch filename formats

### DIFF
--- a/docs/roms/patching.md
+++ b/docs/roms/patching.md
@@ -50,23 +50,15 @@ Igir needs to be able to know what source ROM each patch file applies to, and it
 
 A few patch formats include the source ROM's CRC32 checksum in the patch's file contents. This is the most accurate and therefore the best way to get source ROM information. `.bps` is a great example of an efficient and simple patch format that includes this information.
 
-Most patch formats _do not_ include the source ROM's CRC32 checksum. `.ips` patches are some of the most likely you will come across. For those patches, you need to put the source ROM's CRC32 checksum in the patch's filename, either at the beginning or end, like this:
+Most patch formats _do not_ include the source ROM's CRC32 checksum. `.ips` patches are some of the most likely you will come across. For those patches, you need to put the source ROM's CRC32 checksum in the patch's filename. Here are some examples:
 
-```text
-Source ROM filename:
-Super Mario Land (World).gb
-
-Patch filename:
-Super Mario Land DX v2.0 (World) 90776841.ips
-```
-
-```text
-Source ROM filename:
-NBA Jam - Tournament Edition (USA) (Track 1).bin
-
-Patch filename:
-a8f1adf5 NBA Jam 22 v1.4.ppf
-```
+| Source ROM filename                                | Patch filename                                                                                      |
+|----------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `Super Mario Land (World).gb`                      | At the end: `Super Mario Land DX v2.0 (World) 90776841.ips`                                         |
+| `NBA Jam - Tournament Edition (USA) (Track 1).bin` | At the beginning: `A8F1ADF5 NBA Jam 22 v1.4.ppf`                                                    |
+| `Mega Man - Dr. Wily's Revenge (USA).gb`           | In square brackets: `Mega Man - Dr. Wily's Revenge DX v1.02 (USA) [47e70e08].ips`                   |
+| `Metroid II - Return of Samus (World).gb`          | In parentheses: `Metroid II - Return of Samus DX v2.0 (World) (DEE05370).ips`                       |
+| `Pokemon Card GB 2 - GR Dan Sanjou! (Japan).gbc`   | With an 0x prefix: `Pokemon Card GB 2 - GR Dan Sanjou! (Japan) 0x6c933a14 [T+En1.0_Artemis251].gbc` |
 
 ## Only writing patched ROMs
 

--- a/src/types/patches/patch.ts
+++ b/src/types/patches/patch.ts
@@ -22,9 +22,9 @@ export default abstract class Patch {
   }
 
   protected static getCrcFromPath(fileBasename: string): string {
-    const matches = /(^|[^a-z0-9])([a-f0-9]{8})([^a-z0-9]|$)/i.exec(fileBasename);
+    const matches = /(^|[^a-z0-9])(0x)?([a-f0-9]{8})([^a-z0-9]|$)/i.exec(fileBasename);
     if (matches && matches.length >= 3) {
-      return matches[2].toLowerCase();
+      return matches[3].toLowerCase();
     }
 
     throw new IgirException(`couldn't parse base file CRC for patch: ${fileBasename}`);

--- a/test/types/files/file.test.ts
+++ b/test/types/files/file.test.ts
@@ -451,9 +451,15 @@ describe('createReadStream', () => {
 });
 
 describe('withPatch', () => {
-  it('should attach a matching patch', async () => {
-    const file = await File.fileOf({ filePath: 'file.rom', size: 0, crc32: '00000000' });
-    const patch = IPSPatch.patchFrom(await File.fileOf({ filePath: 'patch 00000000.ips' }));
+  test.each([
+    'patch deadbeef.ips',
+    'DEADBEEF patch.ips',
+    'patch [DEADbeef].ips',
+    'patch (deadBEEF).ips',
+    'patch 0xdeadbeef.ips',
+  ])('should attach a matching patch: %s', async (filePath) => {
+    const file = await File.fileOf({ filePath: 'file.rom', size: 0, crc32: 'DEADBEEF' });
+    const patch = IPSPatch.patchFrom(await File.fileOf({ filePath }));
     const patchedFile = file.withPatch(patch);
     expect(patchedFile.getPatch()).toEqual(patch);
   });


### PR DESCRIPTION
RE: https://github.com/emmercm/igir/discussions/2065